### PR TITLE
feat: moved installing dependencies to a user land

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If something doesn’t work, please [file an issue](https://github.com/contentfu
 
 ```sh
 npx @contentful/create-contentful-extension my-first-extension
-cd my-first-extension
+cd my-first-extension && npm install
 npm run login && npm run start
 ```
 

--- a/packages/contentful-extension-scripts/scripts/init.js
+++ b/packages/contentful-extension-scripts/scripts/init.js
@@ -7,6 +7,7 @@ const chalk = require('chalk');
 const generateExtensionFile = require('./utils/generateExtensionFile');
 const updatePackageJsonFile = require('./utils/updatePackageJsonFile');
 const showHelp = require('./utils/showHelp');
+const { version } = require('../package.json');
 
 module.exports = (appPath, payload, originalDirectory) => {
   const { name, type, fields } = payload;
@@ -16,7 +17,7 @@ module.exports = (appPath, payload, originalDirectory) => {
   const ownPath = path.join(appPath, 'node_modules', ownPackageName);
   let appPackage = require(path.join(appPath, 'package.json'));
 
-  appPackage = updatePackageJsonFile(appPackage);
+  appPackage = updatePackageJsonFile(appPackage, version);
 
   fs.writeFileSync(
     path.join(appPath, 'package.json'),
@@ -61,7 +62,9 @@ module.exports = (appPath, payload, originalDirectory) => {
   console.log();
   console.log(chalk.cyan('  cd'), cdpath);
   console.log(
-    `  ${displayedCommand} login && ${chalk.cyan(`${displayedCommand} start`)}`
+    `  ${chalk.cyan(
+      `npm install && ${displayedCommand} login && ${displayedCommand} start`
+    )}`
   );
   console.log();
   console.log('Happy hacking and enjoy Contentful UI Extensions!');

--- a/packages/contentful-extension-scripts/scripts/utils/updatePackageJsonFile.js
+++ b/packages/contentful-extension-scripts/scripts/utils/updatePackageJsonFile.js
@@ -1,4 +1,4 @@
-module.exports = pkg => {
+module.exports = (pkg, version) => {
   pkg.dependencies = pkg.dependencies || {};
   pkg.scripts = {
     prestart:
@@ -10,6 +10,24 @@ module.exports = pkg => {
     login: 'contentful login',
     logout: 'contentful logout',
     help: 'contentful-extension-scripts help',
+  };
+  pkg.devDependencies = {
+    '@babel/core': '^7.3.4',
+    '@babel/plugin-proposal-class-properties': '^7.3.4',
+    '@babel/plugin-transform-runtime': '^7.3.4',
+    '@babel/preset-env': '^7.3.4',
+    '@babel/preset-react': '^7.0.0',
+    '@contentful/contentful-extension-scripts': version,
+    'contentful-cli': '0.24.0',
+  };
+  pkg.dependencies = {
+    '@contentful/forma-36-fcss': '^0.0.15',
+    '@contentful/forma-36-react-components': '^2.9.14',
+    '@contentful/forma-36-tokens': '^0.2.2',
+    'contentful-ui-extensions-sdk': '3.7.0',
+    'prop-types': '^15.7.2',
+    react: '^16.8.4',
+    'react-dom': '^16.8.4',
   };
   pkg.browserslist = ['last 5 Chrome version', '> 1%', 'not ie <= 11'];
   return pkg;

--- a/packages/create-contentful-extension/lib/create-contentful-extension.js
+++ b/packages/create-contentful-extension/lib/create-contentful-extension.js
@@ -49,7 +49,6 @@ function install(root, dependencies, verbose, isDev) {
       root,
       isDev ? '--save-dev' : '--save',
       '--save-exact',
-      '--no-package-lock',
       '--loglevel',
       'error',
     ].concat(dependencies);
@@ -72,32 +71,14 @@ function install(root, dependencies, verbose, isDev) {
 }
 
 function run(root, payload, verbose, originalDirectory) {
-  const allDependencies = [
-    '@contentful/forma-36-react-components',
-    '@contentful/forma-36-tokens',
-    '@contentful/forma-36-fcss',
-    'contentful-ui-extensions-sdk',
-    'react',
-    'react-dom',
-    'prop-types',
-  ];
-
   const devDependencies = [
-    'contentful-cli',
-    '@babel/core',
-    '@babel/preset-env',
-    '@babel/preset-react',
-    '@babel/plugin-proposal-class-properties',
-    '@babel/plugin-transform-runtime',
     // path.resolve('./packages/contentful-extension-scripts'),
     '@contentful/contentful-extension-scripts',
   ];
 
   return install(root, devDependencies, verbose, true).then(() => {
-    install(root, allDependencies, verbose, false).then(() => {
-      const init = require(`${root}/node_modules/@contentful/contentful-extension-scripts/scripts/init.js`);
-      init(root, payload, originalDirectory);
-    });
+    const init = require(`${root}/node_modules/@contentful/contentful-extension-scripts/scripts/init.js`);
+    init(root, payload, originalDirectory);
   });
 }
 


### PR DESCRIPTION
It turned out that current version doesn't work properly on Windows, because using `npm install` in a script doesn't update `package.json`. This PR moves all list of dependencies from `create-contentful-extension` to `contentful-extension-scripts`.

Advantages:
* Dependencies are collocated with templates which is good in case of breaking changes in any of the dependencies.
* Really quick `npx @contenful/create-contentful-extension` command
* Fixes problem on Windows

Disadvantages:
* User is asked to do `npm install` after generation