### PR TITLE
Add support for multiple extensions in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,9 @@ Use `npm run configure` command. It asks what space and environment you'd like t
 
 ### I want to serve extension in development mode from custom port number (not default 1234). Is it possible?
 
-Yes, it's possible. Edit `prestart` and `start` scripts in package.json file according to the following example:
+Yes, it's possible. Edit `start` scripts in package.json file according to the following example:
 
 ```json
-"prestart": "contentful space use && contentful extension update --src http://localhost:8000 --force",
 "start": "contentful-extension-scripts start --port 8000",
 ```
 
@@ -173,10 +172,9 @@ In development mode, extension is served from `http://localhost:1234`, but `app.
 
 ### I'm not the biggest fan of disabling the mixed content setting in browsers. Can I use HTTPS in development mode?
 
-Yes, you can serve your extension using HTTPS. Add `--https` to `start` command and update url in `prestart` command.
+Yes, you can serve your extension using HTTPS. Add `--https` to `start` command.
 
 ```
-"prestart": "contentful extension update --src https://localhost:1234 --force",
 "start": "contentful-extension-scripts start --https",
 ```
 

--- a/packages/contentful-extension-scripts/scripts/start.js
+++ b/packages/contentful-extension-scripts/scripts/start.js
@@ -12,32 +12,30 @@ const entry = paths.src + '/index.html';
 const https = argv.https || false;
 const port = argv.port || 1234;
 
-updateExtension(https, port).then(() => {
-  // Bundler options
-  const options = {
-    outDir: paths.build, // The out directory to put the build files in, defaults to dist
-    outFile: 'index.html', // The name of the outputFile
-    watch: true, // Whether to watch the files and rebuild them on change, defaults to process.env.NODE_ENV !== 'production'
-    cache: true, // Enabled or disables caching, defaults to true
-    cacheDir: paths.cache, // The directory cache gets put in, defaults to .cache
-    contentHash: false, // Disable content hash from being included on the filename
-    minify: false, // Minify files, enabled if process.env.NODE_ENV === 'production'
-    scopeHoist: false, // Turn on experimental scope hoisting/tree shaking flag, for smaller production bundles
-    logLevel: 3, // 5 = save everything to a file, 4 = like 3, but with timestamps and additionally log http requests to dev server, 3 = log info, warnings & errors, 2 = log warnings & errors, 1 = log errors
-    hmr: true, // Enable or disable HMR while watching
-    hmrPort: 0, // The port the HMR socket runs on
-    sourceMaps: true, // Enable or disable sourcemaps, defaults to enabled (minified builds currently always create sourcemaps)
-    hmrHostname: '', // A hostname for hot module reload, default to ''
-    detailedReport: false, // Prints a detailed report of the bundles, assets, filesizes and times, defaults to false, reports are only printed if watch is disabled
-    https: https, // This flag generates a self-signed certificate, you might have to configure your browser to allow self-signed certificates for localhost
-    autoInstall: false, // Disable auto install
-  };
+const options = {
+  outDir: paths.build, // The out directory to put the build files in, defaults to dist
+  outFile: 'index.html', // The name of the outputFile
+  watch: true, // Whether to watch the files and rebuild them on change, defaults to process.env.NODE_ENV !== 'production'
+  cache: true, // Enabled or disables caching, defaults to true
+  cacheDir: paths.cache, // The directory cache gets put in, defaults to .cache
+  contentHash: false, // Disable content hash from being included on the filename
+  minify: false, // Minify files, enabled if process.env.NODE_ENV === 'production'
+  scopeHoist: false, // Turn on experimental scope hoisting/tree shaking flag, for smaller production bundles
+  logLevel: 3, // 5 = save everything to a file, 4 = like 3, but with timestamps and additionally log http requests to dev server, 3 = log info, warnings & errors, 2 = log warnings & errors, 1 = log errors
+  hmr: true, // Enable or disable HMR while watching
+  hmrPort: 0, // The port the HMR socket runs on
+  sourceMaps: true, // Enable or disable sourcemaps, defaults to enabled (minified builds currently always create sourcemaps)
+  hmrHostname: '', // A hostname for hot module reload, default to ''
+  detailedReport: false, // Prints a detailed report of the bundles, assets, filesizes and times, defaults to false, reports are only printed if watch is disabled
+  https: https, // This flag generates a self-signed certificate, you might have to configure your browser to allow self-signed certificates for localhost
+  autoInstall: false, // Disable auto install
+};
 
-  const bundler = new Bundler(entry, options);
+const bundler = new Bundler(entry, options);
 
-  const run = async () => {
-    await bundler.serve(port, https);
-  };
+const run = async (https, port) => {
+  await updateExtension(https, port);
+  await bundler.serve(port, https);
+};
 
-  run();
-});
+run(https, port);

--- a/packages/contentful-extension-scripts/scripts/start.js
+++ b/packages/contentful-extension-scripts/scripts/start.js
@@ -6,35 +6,38 @@ const argv = require('yargs').argv;
 
 const Bundler = require('parcel-bundler');
 const paths = require('./utils/paths');
+const updateExtension = require('./utils/updateExtension');
 
 const entry = paths.src + '/index.html';
 const https = argv.https || false;
 const port = argv.port || 1234;
 
-// Bundler options
-const options = {
-  outDir: paths.build, // The out directory to put the build files in, defaults to dist
-  outFile: 'index.html', // The name of the outputFile
-  watch: true, // Whether to watch the files and rebuild them on change, defaults to process.env.NODE_ENV !== 'production'
-  cache: true, // Enabled or disables caching, defaults to true
-  cacheDir: paths.cache, // The directory cache gets put in, defaults to .cache
-  contentHash: false, // Disable content hash from being included on the filename
-  minify: false, // Minify files, enabled if process.env.NODE_ENV === 'production'
-  scopeHoist: false, // Turn on experimental scope hoisting/tree shaking flag, for smaller production bundles
-  logLevel: 3, // 5 = save everything to a file, 4 = like 3, but with timestamps and additionally log http requests to dev server, 3 = log info, warnings & errors, 2 = log warnings & errors, 1 = log errors
-  hmr: true, // Enable or disable HMR while watching
-  hmrPort: 54321, // The port the HMR socket runs on
-  sourceMaps: true, // Enable or disable sourcemaps, defaults to enabled (minified builds currently always create sourcemaps)
-  hmrHostname: '', // A hostname for hot module reload, default to ''
-  detailedReport: false, // Prints a detailed report of the bundles, assets, filesizes and times, defaults to false, reports are only printed if watch is disabled
-  https: https, // This flag generates a self-signed certificate, you might have to configure your browser to allow self-signed certificates for localhost
-  autoInstall: false, // Disable auto install
-};
+updateExtension(https, port).then(() => {
+  // Bundler options
+  const options = {
+    outDir: paths.build, // The out directory to put the build files in, defaults to dist
+    outFile: 'index.html', // The name of the outputFile
+    watch: true, // Whether to watch the files and rebuild them on change, defaults to process.env.NODE_ENV !== 'production'
+    cache: true, // Enabled or disables caching, defaults to true
+    cacheDir: paths.cache, // The directory cache gets put in, defaults to .cache
+    contentHash: false, // Disable content hash from being included on the filename
+    minify: false, // Minify files, enabled if process.env.NODE_ENV === 'production'
+    scopeHoist: false, // Turn on experimental scope hoisting/tree shaking flag, for smaller production bundles
+    logLevel: 3, // 5 = save everything to a file, 4 = like 3, but with timestamps and additionally log http requests to dev server, 3 = log info, warnings & errors, 2 = log warnings & errors, 1 = log errors
+    hmr: true, // Enable or disable HMR while watching
+    hmrPort: 0, // The port the HMR socket runs on
+    sourceMaps: true, // Enable or disable sourcemaps, defaults to enabled (minified builds currently always create sourcemaps)
+    hmrHostname: '', // A hostname for hot module reload, default to ''
+    detailedReport: false, // Prints a detailed report of the bundles, assets, filesizes and times, defaults to false, reports are only printed if watch is disabled
+    https: https, // This flag generates a self-signed certificate, you might have to configure your browser to allow self-signed certificates for localhost
+    autoInstall: false, // Disable auto install
+  };
 
-const bundler = new Bundler(entry, options);
+  const bundler = new Bundler(entry, options);
 
-const run = async () => {
-  await bundler.serve(port, https);
-};
+  const run = async () => {
+    await bundler.serve(port, https);
+  };
 
-run();
+  run();
+});

--- a/packages/contentful-extension-scripts/scripts/utils/updateExtension.js
+++ b/packages/contentful-extension-scripts/scripts/utils/updateExtension.js
@@ -1,7 +1,7 @@
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
-module.exports = async (https = false, port = 1234) => {
+module.exports = async (https, port) => {
   await exec(
     `contentful extension update --src ${
       https ? 'https' : 'http'

--- a/packages/contentful-extension-scripts/scripts/utils/updateExtension.js
+++ b/packages/contentful-extension-scripts/scripts/utils/updateExtension.js
@@ -2,11 +2,9 @@ const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
 module.exports = async (https = false, port = 1234) => {
-  const { stdout, stderr } = await exec(
+  await exec(
     `contentful extension update --src ${
       https ? 'https' : 'http'
     }://localhost:${port} --force`
   );
-  console.log('stdout:', stdout);
-  console.log('stderr:', stderr);
 };

--- a/packages/contentful-extension-scripts/scripts/utils/updateExtension.js
+++ b/packages/contentful-extension-scripts/scripts/utils/updateExtension.js
@@ -1,0 +1,12 @@
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+module.exports = async (https = false, port = 1234) => {
+  const { stdout, stderr } = await exec(
+    `contentful extension update --src ${
+      https ? 'https' : 'http'
+    }://localhost:${port} --force`
+  );
+  console.log('stdout:', stdout);
+  console.log('stderr:', stderr);
+};

--- a/packages/contentful-extension-scripts/scripts/utils/updatePackageJsonFile.js
+++ b/packages/contentful-extension-scripts/scripts/utils/updatePackageJsonFile.js
@@ -1,7 +1,6 @@
 module.exports = (pkg, { version, language }) => {
   pkg.dependencies = pkg.dependencies || {};
   pkg.scripts = {
-    prestart: 'contentful extension update --src http://localhost:1234 --force',
     start: 'contentful-extension-scripts start',
     build: 'contentful-extension-scripts build',
     deploy: 'npm run build && contentful extension update --force',


### PR DESCRIPTION
With this pull request, I wanted to add support for running multiple extensions in development mode at the same time. This wasn't possible yet, because of a conflict with the port numbers that were used for the hot module reload functionality of `parcel-bundler`. 

After I fixed that problem, I wanted to make it easier to change the port number and enabling/disabling the https functionality. So I deleted the prestart command and made it part of the normal start script. The benefit of this is that we're now able to change the port and change the HTTP/HTTPS functionality, by adding it as an argument to the start command. Example `npm run start --port=8080 --https` works fine now.  

I'm open to any feedback, so let me know what you think.