### PR TITLE
using UTC time when running jest tests

### DIFF
--- a/packages/contentful-extension-scripts/scripts/test.js
+++ b/packages/contentful-extension-scripts/scripts/test.js
@@ -1,6 +1,7 @@
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'test';
 process.env.NODE_ENV = 'test';
+process.env.TZ = 'UTC';
 const createJestConfig = require('./utils/createJestConfig');
 const paths = require('./utils/paths');
 const fs = require('fs');


### PR DESCRIPTION
Jest tests with time logic should run on UTC to ensure all tests portray the same time accurately.