### PR TITLE
fix: :bug: replace fs with fs-extra, cause #readJSONSync lives there

### DIFF
--- a/packages/contentful-extension-scripts/scripts/test.js
+++ b/packages/contentful-extension-scripts/scripts/test.js
@@ -3,7 +3,7 @@ process.env.BABEL_ENV = 'test';
 process.env.NODE_ENV = 'test';
 const createJestConfig = require('./utils/createJestConfig');
 const paths = require('./utils/paths');
-const fs = require('fs');
+const fs = require('fs-extra');
 const jest = require('jest');
 
 const argv = process.argv.slice(2);


### PR DESCRIPTION
Now it is not possible to extend jest config, cause

```
try {
  appPackageJson = fs.readJSONSync(paths.packageJson);
} catch (e) {
  // do nothing
}
```

always failing.