### PR TITLE
Fix broken output

### DIFF
--- a/packages/contentful-extension-scripts/package.json
+++ b/packages/contentful-extension-scripts/package.json
@@ -44,7 +44,7 @@
     "identity-obj-proxy": "3.0.0",
     "jest": "^25.1.0",
     "jest-watch-typeahead": "^0.4.2",
-    "parcel-bundler": "^1.12.4",
+    "parcel-bundler": "1.12.4",
     "parcel-plugin-url-loader": "1.3.1",
     "posthtml": "0.12.0",
     "posthtml-inline-assets": "3.0.0",

--- a/packages/contentful-extension-scripts/template/javascript-fields/src/index.js
+++ b/packages/contentful-extension-scripts/template/javascript-fields/src/index.js
@@ -13,7 +13,7 @@ export const App = ({sdk}) => {
     setValue(value);
   }
 
-  onChange = e => {
+  const onChange = e => {
     const value = e.currentTarget.value;
     setValue(value);
     if (value) {


### PR DESCRIPTION
Two fixes!

## Fix one
Remove the carat from Parcel to lock it to a set version, because otherwise it was bringing in a newer version of babel that was causing this build error. This seems to be pretty new, people have been [reporting it in other projects](https://github.com/babel/babel/issues/11622) over the past couple of days
![image](https://user-images.githubusercontent.com/20307225/83276560-14f41a00-a1d1-11ea-8a38-56ff43e53ac0.png)

## Fix two
In changing to use hooks, we hadn't properly converted a class property that was there before. This failed at run time because `onChange` wasn't initialised.

