### PR TITLE
feat: Enable build cacheing

### DIFF
--- a/packages/contentful-extension-scripts/scripts/build.js
+++ b/packages/contentful-extension-scripts/scripts/build.js
@@ -33,7 +33,7 @@ const options = {
   outFile: 'index.html', // The name of the outputFile
   target: 'browser',
   watch: false, // Whether to watch the files and rebuild them on change, defaults to process.env.NODE_ENV !== 'production'
-  cache: false, // Enabled or disables caching, defaults to true
+  cache: true, // Enabled or disables caching, defaults to true
   contentHash: true, // Include a content hash in the outputted filenames
   minify: true, // Minify files, enabled if process.env.NODE_ENV === 'production'
   scopeHoist: false, // Turn on experimental scope hoisting/tree shaking flag, for smaller production bundles

--- a/packages/contentful-extension-scripts/scripts/build.js
+++ b/packages/contentful-extension-scripts/scripts/build.js
@@ -28,8 +28,8 @@ const entry = paths.src + '/index.html';
 
 // Bundler options
 const options = {
-  outDir: paths.build,
-  publicUrl: publicUrl, // The out directory to put the build files in, defaults to dist
+  outDir: paths.build, // The out directory to put the build files in, defaults to dist
+  publicUrl: publicUrl,
   outFile: 'index.html', // The name of the outputFile
   target: 'browser',
   watch: false, // Whether to watch the files and rebuild them on change, defaults to process.env.NODE_ENV !== 'production'


### PR DESCRIPTION
while working on the hashing issue, I noticed that we were disabling cacheing. I quickly tested this on the default output of CCE and it took my build times with a small change from ~6 seconds to ~700 milliseconds.

