### PR TITLE
Add jest config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ It correctly bundles React and all dependencies in production mode and optimizes
 
 ### `npm run test`
 
-Run jest runner in watch mode. Passes through all flats directly to Jest
+Run jest runner in watch mode. Passes through all flats directly to Jest. If you happen to have a local jest configuration file (i.e: `jest.config.js`), testing only supports exporting a config object (as opposed to functions).
 
 ### `npm run login`
 

--- a/packages/contentful-extension-scripts/package-lock.json
+++ b/packages/contentful-extension-scripts/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@contentful/contentful-extension-scripts",
-	"version": "0.19.0",
+	"version": "0.19.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/contentful-extension-scripts/package.json
+++ b/packages/contentful-extension-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/contentful-extension-scripts",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Configuration and scripts for Create Contentful Extension",
   "keywords": [
     "contentful",

--- a/packages/contentful-extension-scripts/scripts/utils/createJestConfig.js
+++ b/packages/contentful-extension-scripts/scripts/utils/createJestConfig.js
@@ -1,4 +1,12 @@
 const paths = require('./paths');
+const path = require('path');
+const fs = require('fs');
+
+let jestConfig = {};
+
+if (fs.existsSync(path.resolve('jest.config.js'))) {
+  jestConfig = require(path.resolve('jest.config.js'));
+}
 
 module.exports = function createJestConfig() {
   const config = {
@@ -24,7 +32,8 @@ module.exports = function createJestConfig() {
     watchPlugins: [
       require.resolve('jest-watch-typeahead/filename'),
       require.resolve('jest-watch-typeahead/testname')
-    ]
+    ],
+    ...jestConfig
   };
 
   return config;


### PR DESCRIPTION
Question here is do we want to support all possible jest configs? It could return an async config function, object or even inside package.json.

Fixes: #83 