### PR TITLE
chore: add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,43 @@
+# https://dependabot.com/docs/config-file/#dependabot-config-files
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "in_range"
+  - package_manager: "javascript"
+    directory: "packages/contentful-extension-scripts"
+    update_schedule: "daily"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "in_range" 
+  - package_manager: "javascript"
+    directory: "packages/create-contentful-extension"
+    update_schedule: "daily"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "in_range" 
+  - package_manager: "javascript"
+    directory: "packages/eslint-config-extension"
+    update_schedule: "daily"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "in_range" 

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,40 +4,12 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "daily"
-    automerged_updates:
-      - match:
-          dependency_type: "development"
-          update_type: "all"
-      - match:
-          dependency_type: "production"
-          update_type: "in_range"
   - package_manager: "javascript"
     directory: "packages/contentful-extension-scripts"
     update_schedule: "daily"
-    automerged_updates:
-      - match:
-          dependency_type: "development"
-          update_type: "all"
-      - match:
-          dependency_type: "production"
-          update_type: "in_range" 
   - package_manager: "javascript"
     directory: "packages/create-contentful-extension"
     update_schedule: "daily"
-    automerged_updates:
-      - match:
-          dependency_type: "development"
-          update_type: "all"
-      - match:
-          dependency_type: "production"
-          update_type: "in_range" 
   - package_manager: "javascript"
     directory: "packages/eslint-config-extension"
     update_schedule: "daily"
-    automerged_updates:
-      - match:
-          dependency_type: "development"
-          update_type: "all"
-      - match:
-          dependency_type: "production"
-          update_type: "in_range" 


### PR DESCRIPTION
We are currently not updating our dependencies - neither automatically nor manually.

We do not automatically merge dependabot PRs as there is currently no automatic testing in this repository.