### PR TITLE
fix(contentful-extension-scripts): make render a class method

### DIFF
--- a/packages/contentful-extension-scripts/template/javascript-page/src/index.js
+++ b/packages/contentful-extension-scripts/template/javascript-page/src/index.js
@@ -41,7 +41,7 @@ export class PageExtension extends React.Component {
     });
   }
 
-  render = () => {
+  render() {
     return (
       <div className="f36-margin--l">
         <Router history={this.history}>

--- a/packages/contentful-extension-scripts/template/typescript-fields/src/index.tsx
+++ b/packages/contentful-extension-scripts/template/typescript-fields/src/index.tsx
@@ -50,7 +50,7 @@ export class App extends React.Component<AppProps, AppState> {
     }
   };
 
-  render = () => {
+  render() {
     return (
       <TextInput
         width="large"

--- a/packages/contentful-extension-scripts/template/typescript-page/src/index.tsx
+++ b/packages/contentful-extension-scripts/template/typescript-page/src/index.tsx
@@ -59,7 +59,7 @@ export class PageExtension extends React.Component<PageExtensionProps> {
     });
   }
 
-  render = () => {
+  render() {
     return (
       <div className="f36-margin--l">
         <Router history={this.history}>


### PR DESCRIPTION
When creating a new extension, the build failed because "Support for the
experimental syntax classProperties isn't currently enabled." The render
methods used class properties without any obvious reason and can be
simply replaced with a regular method to make the build succeed.