### PR TITLE
fix: remove non-existing camelcase rule

### DIFF
--- a/packages/eslint-config-extension/typescript.js
+++ b/packages/eslint-config-extension/typescript.js
@@ -18,9 +18,8 @@ module.exports = {
   },
   rules: {
     '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/camelcase': ['warn', { properties: 'never' }],
     '@typescript-eslint/explicit-member-accessibility': 'off',
-    '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '^_' }],
     '@typescript-eslint/no-for-in-array': 'error',
     '@typescript-eslint/unified-signatures': 'warn',
     '@typescript-eslint/prefer-interface': 'off',

--- a/packages/eslint-config-extension/typescript.js
+++ b/packages/eslint-config-extension/typescript.js
@@ -19,7 +19,7 @@ module.exports = {
   rules: {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/no-for-in-array': 'error',
     '@typescript-eslint/unified-signatures': 'warn',
     '@typescript-eslint/prefer-interface': 'off',


### PR DESCRIPTION
The `camelcase` rule got replaced since v3 of the ts-eslint-parser. ~~Plus relax a bit on the unused vars.~~