### PR TITLE
feat(contentful-extension-scripts): updateOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ If you simply want to serve the extension without having the CLI create or updat
 "start": "contentful-extension-scripts start --serve-only",
 ```
 
+### I want to create/update the extension without starting the parcel server
+
+If you simply want to serve the extension without having the CLI start its parcel server, you can add `--update-only` to the `start` command.
+
+```json
+"start": "contentful-extension-scripts start --update-only",
+```
+
 Available since v0.14.0
 
 ### I'm using development mode but my extension is not showing up. What's wrong?

--- a/packages/contentful-extension-scripts/scripts/start.js
+++ b/packages/contentful-extension-scripts/scripts/start.js
@@ -40,7 +40,9 @@ const run = async () => {
       await updateExtension(port, https);
     }
 
-    await bundler.serve(port, https);
+    if(!argv.updateOnly){
+      await bundler.serve(port, https);
+    }
   } catch (e) {
     console.log();
     console.error(chalk.red(e.message));


### PR DESCRIPTION
Command line option to add --update-only which won't bundle/serve an extension while in dev mode

```
contentful-extension-scripts start --update-only
```

This can be used if you don't want to use parcel